### PR TITLE
Add basic 3D maze navigator scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# sandbox
+# 3D Maze AI Navigator
+
+This project is a simplified educational tool for exploring maze generation and basic AI navigation in a 3D environment with Three.js. It is a static web application designed for hosting on GitHub Pages.
+
+## Getting Started
+
+Open `index.html` in a modern web browser with WebGL support. Use the **Generate Maze** button to create a maze and **AI Step** to move the agent using a wall-following strategy.
+
+## Folder Structure
+
+- `css/` – Stylesheet
+- `js/` – JavaScript modules
+- `docs/` – Documentation
+
+More advanced algorithms and features can be added following the modular structure provided.

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,26 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+    background: #1e1e1e;
+    color: #fff;
+}
+header {
+    text-align: center;
+    padding: 1rem;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(10px);
+}
+#renderer-container {
+    width: 100%;
+    height: calc(100vh - 100px);
+    display: block;
+}
+#controls {
+    position: absolute;
+    top: 80px;
+    left: 20px;
+    z-index: 10;
+}
+button {
+    margin: 0.25rem;
+}

--- a/docs/SRD.md
+++ b/docs/SRD.md
@@ -1,0 +1,3 @@
+# System Reference Document
+
+This project demonstrates maze generation algorithms and basic AI navigation strategies in a 3D environment using Three.js. The goal is educational, providing simple visuals and code for learners to explore.

--- a/index.html
+++ b/index.html
@@ -1,3 +1,29 @@
-cd architectVS7.github.io
-
-echo "Hello World" > index.html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>3D Maze AI Navigator</title>
+    <link rel="stylesheet" href="css/styles.css">
+</head>
+<body>
+    <header>
+        <h1>3D Maze AI Navigator</h1>
+    </header>
+    <main>
+        <div id="controls"></div>
+        <div id="renderer-container"></div>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/build/three.min.js"></script>
+    <script src="js/ui/eventBus.js"></script>
+    <script src="js/config.js"></script>
+    <script src="js/utils/mazeUtils.js"></script>
+    <script src="js/algorithms/mazeGenerator.js"></script>
+    <script src="js/algorithms/aiNavigator.js"></script>
+    <script src="js/3d/materials.js"></script>
+    <script src="js/3d/geometry.js"></script>
+    <script src="js/3d/scene.js"></script>
+    <script src="js/ui/controls.js"></script>
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/js/3d/geometry.js
+++ b/js/3d/geometry.js
@@ -1,0 +1,45 @@
+import { CONFIG } from '../config.js';
+
+export function createMazeMesh(maze) {
+    const group = new THREE.Group();
+    const wallGeo = new THREE.BoxGeometry(CONFIG.cellSize, 1, CONFIG.cellSize);
+    const wallMat = new THREE.MeshStandardMaterial({ color: 0x5555ff });
+
+    maze.forEach(row => {
+        row.forEach(cell => {
+            const { x, y, walls } = cell;
+            const half = CONFIG.cellSize / 2;
+            if (walls[0]) {
+                const wall = new THREE.Mesh(wallGeo, wallMat);
+                wall.position.set(x * CONFIG.cellSize, 0.5, y * CONFIG.cellSize - half);
+                group.add(wall);
+            }
+            if (walls[1]) {
+                const wall = new THREE.Mesh(wallGeo, wallMat);
+                wall.position.set(x * CONFIG.cellSize + half, 0.5, y * CONFIG.cellSize);
+                wall.rotation.y = Math.PI / 2;
+                group.add(wall);
+            }
+            if (walls[2]) {
+                const wall = new THREE.Mesh(wallGeo, wallMat);
+                wall.position.set(x * CONFIG.cellSize, 0.5, y * CONFIG.cellSize + half);
+                group.add(wall);
+            }
+            if (walls[3]) {
+                const wall = new THREE.Mesh(wallGeo, wallMat);
+                wall.position.set(x * CONFIG.cellSize - half, 0.5, y * CONFIG.cellSize);
+                wall.rotation.y = Math.PI / 2;
+                group.add(wall);
+            }
+        });
+    });
+    return group;
+}
+
+export function createAIMesh() {
+    const geometry = new THREE.SphereGeometry(CONFIG.cellSize / 4, 16, 16);
+    const material = new THREE.MeshStandardMaterial({ color: 0xff5555 });
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.y = 0.5;
+    return mesh;
+}

--- a/js/3d/materials.js
+++ b/js/3d/materials.js
@@ -1,0 +1,1 @@
+// placeholder for future educational materials

--- a/js/3d/scene.js
+++ b/js/3d/scene.js
@@ -1,0 +1,43 @@
+import { CONFIG } from '../config.js';
+import { createMazeMesh, createAIMesh } from './geometry.js';
+
+let scene, camera, renderer, aiMesh;
+
+export function initScene(maze) {
+    scene = new THREE.Scene();
+    camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera.position.set(CONFIG.mazeWidth, CONFIG.mazeHeight * 1.5, CONFIG.mazeWidth);
+    camera.lookAt(0, 0, 0);
+
+    renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.getElementById('renderer-container').appendChild(renderer.domElement);
+
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(1, 1, 1);
+    scene.add(light);
+
+    const mazeMesh = createMazeMesh(maze);
+    scene.add(mazeMesh);
+
+    aiMesh = createAIMesh();
+    scene.add(aiMesh);
+
+    window.addEventListener('resize', onWindowResize);
+    animate();
+}
+
+export function updateAIPosition(x, y) {
+    aiMesh.position.set(x * CONFIG.cellSize, 0.5, y * CONFIG.cellSize);
+}
+
+function onWindowResize() {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+    requestAnimationFrame(animate);
+    renderer.render(scene, camera);
+}

--- a/js/algorithms/aiNavigator.js
+++ b/js/algorithms/aiNavigator.js
@@ -1,0 +1,32 @@
+import { eventBus } from '../ui/eventBus.js';
+import { CONFIG } from '../config.js';
+
+export class WallFollower {
+    constructor(maze) {
+        this.maze = maze;
+        this.x = 0;
+        this.y = 0;
+        this.dir = 0; // 0: up, 1:right,2:down,3:left
+        this.path = [];
+    }
+
+    step() {
+        this.path.push({ x: this.x, y: this.y });
+        for (let i = 0; i < 4; i++) {
+            const dir = (this.dir + 3 + i) % 4; // turn left first
+            if (!this.maze[this.y][this.x].walls[dir]) {
+                this.move(dir);
+                this.dir = dir;
+                eventBus.emit('aiStep', { x: this.x, y: this.y });
+                return;
+            }
+        }
+    }
+
+    move(dir) {
+        if (dir === 0) this.y--; // up
+        if (dir === 1) this.x++; // right
+        if (dir === 2) this.y++; // down
+        if (dir === 3) this.x--; // left
+    }
+}

--- a/js/algorithms/mazeGenerator.js
+++ b/js/algorithms/mazeGenerator.js
@@ -1,0 +1,55 @@
+import { createGrid, shuffle } from '../utils/mazeUtils.js';
+import { CONFIG } from '../config.js';
+import { eventBus } from '../ui/eventBus.js';
+
+export function generateMaze() {
+    const grid = createGrid(CONFIG.mazeWidth, CONFIG.mazeHeight);
+    const stack = [];
+    const start = grid[0][0];
+    start.visited = true;
+    stack.push(start);
+
+    while (stack.length > 0) {
+        const current = stack.pop();
+        const neighbors = getUnvisitedNeighbors(current, grid);
+        if (neighbors.length > 0) {
+            stack.push(current);
+            shuffle(neighbors);
+            const next = neighbors[0];
+            removeWall(current, next);
+            next.visited = true;
+            stack.push(next);
+            eventBus.emit('mazeStep', { current, next });
+        }
+    }
+
+    return grid;
+}
+
+function getUnvisitedNeighbors(cell, grid) {
+    const neighbors = [];
+    const { x, y } = cell;
+    if (y > 0 && !grid[y-1][x].visited) neighbors.push(grid[y-1][x]);
+    if (x < grid[0].length - 1 && !grid[y][x+1].visited) neighbors.push(grid[y][x+1]);
+    if (y < grid.length - 1 && !grid[y+1][x].visited) neighbors.push(grid[y+1][x]);
+    if (x > 0 && !grid[y][x-1].visited) neighbors.push(grid[y][x-1]);
+    return neighbors;
+}
+
+function removeWall(a, b) {
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    if (dx === 1) {
+        a.walls[1] = false;
+        b.walls[3] = false;
+    } else if (dx === -1) {
+        a.walls[3] = false;
+        b.walls[1] = false;
+    } else if (dy === 1) {
+        a.walls[2] = false;
+        b.walls[0] = false;
+    } else if (dy === -1) {
+        a.walls[0] = false;
+        b.walls[2] = false;
+    }
+}

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,6 @@
+export const CONFIG = {
+    mazeWidth: 10,
+    mazeHeight: 10,
+    cellSize: 4,
+    aiSpeed: 0.5
+};

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,5 @@
+import { setupControls } from './ui/controls.js';
+
+window.addEventListener('DOMContentLoaded', () => {
+    setupControls();
+});

--- a/js/ui/controls.js
+++ b/js/ui/controls.js
@@ -1,0 +1,30 @@
+import { eventBus } from './eventBus.js';
+import { generateMaze } from '../algorithms/mazeGenerator.js';
+import { WallFollower } from '../algorithms/aiNavigator.js';
+import { initScene, updateAIPosition } from '../3d/scene.js';
+import { CONFIG } from '../config.js';
+
+let maze, ai;
+
+function createControls() {
+    const container = document.getElementById('controls');
+    const genBtn = document.createElement('button');
+    genBtn.textContent = 'Generate Maze';
+    genBtn.onclick = () => {
+        maze = generateMaze();
+        initScene(maze);
+        ai = new WallFollower(maze);
+    };
+    const stepBtn = document.createElement('button');
+    stepBtn.textContent = 'AI Step';
+    stepBtn.onclick = () => {
+        if (ai) ai.step();
+    };
+    container.appendChild(genBtn);
+    container.appendChild(stepBtn);
+}
+
+export function setupControls() {
+    createControls();
+    eventBus.on('aiStep', pos => updateAIPosition(pos.x, pos.y));
+}

--- a/js/ui/eventBus.js
+++ b/js/ui/eventBus.js
@@ -1,0 +1,10 @@
+export const eventBus = {
+    events: {},
+    on(event, listener) {
+        if (!this.events[event]) this.events[event] = [];
+        this.events[event].push(listener);
+    },
+    emit(event, data) {
+        (this.events[event] || []).forEach(l => l(data));
+    }
+};

--- a/js/utils/mazeUtils.js
+++ b/js/utils/mazeUtils.js
@@ -1,0 +1,18 @@
+export function createGrid(width, height) {
+    const grid = [];
+    for (let y = 0; y < height; y++) {
+        const row = [];
+        for (let x = 0; x < width; x++) {
+            row.push({ x, y, visited: false, walls: [true, true, true, true] });
+        }
+        grid.push(row);
+    }
+    return grid;
+}
+
+export function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
+    }
+}


### PR DESCRIPTION
## Summary
- add project documentation with basic instructions
- scaffold HTML layout with script references
- implement event bus and minimal UI controls
- add simple maze generator and wall-following AI
- render maze in Three.js scene

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c66745a508327be9c0eeae502930d