### PR TITLE
Add functional text adventure engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# sandbox
+# Sandbox
+
+This repository contains a small text adventure engine located in the `game_engine` directory. The engine supports a pluggable parser, action handlers and a basic display layer. Each file represents a major component of the architecture:
+
+- `GameEngine.js`: central game loop and state container
+- `InputParser.js`: command parser converting user text to actions
+- `ActionHandlers.js`: default action resolution functions
+- `Display.js`: output/rendering helper (console or DOM)
+- `index.js`: convenience entry that wires the pieces together
+
+Additional operational modules are provided in the `operational_modules` folder. These demonstrate how different action sets and parsers can be swapped in:
+
+- `dungeon`: classic fantasy commands (go, attack, look, take)
+- `space`: space mission verbs (fly, shoot, scan, collect)

--- a/game_engine/ActionHandlers.js
+++ b/game_engine/ActionHandlers.js
@@ -1,0 +1,62 @@
+// Basic set of action handlers for the engine
+
+const actions = {
+  /**
+   * Move the player to an adjacent room if possible.
+   */
+  move(state, params = {}) {
+    const direction = params.direction;
+    const room = state.world.rooms?.[state.player.location];
+    const next = room?.exits?.[direction];
+
+    if (!next) {
+      return { state, message: "You can't go that way." };
+    }
+
+    state.player.location = next;
+    const desc = state.world.rooms[next]?.description || 'You arrive somewhere.';
+    return { state, message: desc };
+  },
+
+  /**
+   * Inspect the current room or an item (very simple implementation).
+   */
+  inspect(state, params = {}) {
+    const target = params.target;
+    const room = state.world.rooms?.[state.player.location];
+
+    if (!target) {
+      return { state, message: room?.description || 'Nothing of interest.' };
+    }
+
+    const item = room?.items?.find((i) => i.name === target);
+    if (item) {
+      return { state, message: item.description };
+    }
+
+    return { state, message: "You don't see that here." };
+  },
+
+  /**
+   * Pick up an item from the current room.
+   */
+  pickup(state, params = {}) {
+    const itemName = params.item;
+    const room = state.world.rooms?.[state.player.location];
+    if (!itemName || !room) {
+      return { state, message: "Take what?" };
+    }
+
+    const index = room.items?.findIndex((i) => i.name === itemName);
+    if (index === -1 || index === undefined) {
+      return { state, message: "You don't see that here." };
+    }
+
+    const [item] = room.items.splice(index, 1);
+    state.player.inventory = state.player.inventory || [];
+    state.player.inventory.push(item);
+    return { state, message: `You pick up the ${item.name}.` };
+  },
+};
+
+module.exports = actions;

--- a/game_engine/Display.js
+++ b/game_engine/Display.js
@@ -1,0 +1,18 @@
+// Simple display layer used by the GameEngine
+
+/**
+ * Render output to the browser or console. If an element with id `output`
+ * exists, append the text to it. Otherwise fall back to console.log.
+ */
+function render(output) {
+  if (typeof document !== 'undefined') {
+    const box = document.getElementById('output');
+    if (box) {
+      box.textContent += output + '\n';
+      return;
+    }
+  }
+  console.log(output);
+}
+
+module.exports = { render };

--- a/game_engine/GameEngine.js
+++ b/game_engine/GameEngine.js
@@ -1,0 +1,78 @@
+// Basic text adventure game engine
+const readline = require('readline');
+
+class GameEngine {
+  constructor(options = {}) {
+    // Holds the full game state (player info, world data, etc.)
+    this.state = options.state || {
+      player: { location: 'start' },
+      world: {},
+    };
+
+    // Parser converts raw text to action objects
+    this.parseInput = options.parser || ((text) => ({ type: 'unknown', raw: text }));
+
+    // Action handlers (move, inspect, etc.)
+    this.actions = options.actions || {};
+
+    // Display/render callback
+    this.render = options.render || ((msg) => console.log(msg));
+
+    this.running = false;
+  }
+
+  registerAction(name, handler) {
+    this.actions[name] = handler;
+  }
+
+  /**
+   * Process a single turn of input.
+   * Parses the text, dispatches to the correct action handler, updates state,
+   * and renders the resulting output.
+   */
+  handleInput(text) {
+    const action = this.parseInput(text);
+    const handler = this.actions[action.type];
+
+    if (!handler) {
+      this.render(`I don't understand "${text}".`);
+      return;
+    }
+
+    const result = handler(this.state, action.params || {});
+
+    if (result && result.state) {
+      this.state = result.state;
+    }
+
+    if (result && result.message) {
+      this.render(result.message);
+    }
+  }
+
+  /**
+   * Start a basic CLI loop for testing. Each line of input is processed as a
+   * turn. Call stop() to end the loop.
+   */
+  startCLI() {
+    this.running = true;
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const prompt = () => {
+      if (!this.running) {
+        rl.close();
+        return;
+      }
+      rl.question('> ', (answer) => {
+        this.handleInput(answer);
+        prompt();
+      });
+    };
+    prompt();
+  }
+
+  stop() {
+    this.running = false;
+  }
+}
+
+module.exports = GameEngine;

--- a/game_engine/InputParser.js
+++ b/game_engine/InputParser.js
@@ -1,0 +1,36 @@
+// Basic command parser for the text adventure engine
+
+/**
+ * Convert raw user text into an action object that the engine understands.
+ * @param {string} input
+ * @returns {{type: string, params: object}}
+ */
+function parseInput(input) {
+  const text = (input || '').trim().toLowerCase();
+
+  if (text === '') return { type: 'none' };
+
+  const [verb, ...rest] = text.split(/\s+/);
+  const arg = rest.join(' ');
+
+  switch (verb) {
+    case 'go':
+    case 'move':
+      return { type: 'move', params: { direction: rest[0] } };
+    case 'look':
+    case 'inspect':
+      return { type: 'inspect', params: { target: arg || null } };
+    case 'take':
+    case 'pickup':
+      return { type: 'pickup', params: { item: arg } };
+    case 'attack':
+    case 'hit':
+      return { type: 'attack', params: { target: arg } };
+    case 'quit':
+      return { type: 'quit' };
+    default:
+      return { type: 'unknown', raw: input };
+  }
+}
+
+module.exports = parseInput;

--- a/game_engine/index.js
+++ b/game_engine/index.js
@@ -1,0 +1,25 @@
+const GameEngine = require('./GameEngine');
+const parseInput = require('./InputParser');
+const actionHandlers = require('./ActionHandlers');
+const { render } = require('./Display');
+
+// Create an engine instance wired with the default parser and display.
+const engine = new GameEngine({
+  parser: parseInput,
+  actions: actionHandlers,
+  render,
+});
+
+module.exports = {
+  GameEngine,
+  parseInput,
+  actions: actionHandlers,
+  render,
+  engine,
+};
+
+// If executed directly via `node game_engine`, start the CLI loop.
+if (require.main === module) {
+  engine.render('Welcome to the text adventure!');
+  engine.startCLI();
+}

--- a/operational_modules/dungeon/actions/attack.js
+++ b/operational_modules/dungeon/actions/attack.js
@@ -1,0 +1,4 @@
+module.exports = function attack(state, params = {}) {
+  const target = params.target || 'the darkness';
+  return { state, message: `You attack ${target}, but nothing happens.` };
+};

--- a/operational_modules/dungeon/actions/inspect.js
+++ b/operational_modules/dungeon/actions/inspect.js
@@ -1,0 +1,12 @@
+module.exports = function inspect(state, params = {}) {
+  const target = params.target;
+  const room = state.world.rooms?.[state.player.location];
+  if (!target) {
+    return { state, message: room?.description || 'There is nothing to see.' };
+  }
+  const item = room?.items?.find(i => i.name === target);
+  if (item) {
+    return { state, message: item.description };
+  }
+  return { state, message: "You don't see that here." };
+};

--- a/operational_modules/dungeon/actions/move.js
+++ b/operational_modules/dungeon/actions/move.js
@@ -1,0 +1,11 @@
+module.exports = function move(state, params = {}) {
+  const direction = params.direction;
+  const room = state.world.rooms?.[state.player.location];
+  const next = room?.exits?.[direction];
+  if (!next) {
+    return { state, message: "You can't go that way." };
+  }
+  state.player.location = next;
+  const desc = state.world.rooms?.[next]?.description || `You move ${direction}.`;
+  return { state, message: desc };
+};

--- a/operational_modules/dungeon/actions/pickup.js
+++ b/operational_modules/dungeon/actions/pickup.js
@@ -1,0 +1,15 @@
+module.exports = function pickup(state, params = {}) {
+  const itemName = params.item;
+  const room = state.world.rooms?.[state.player.location];
+  if (!itemName || !room) {
+    return { state, message: 'Take what?' };
+  }
+  const index = room.items?.findIndex(i => i.name === itemName);
+  if (index === -1 || index === undefined) {
+    return { state, message: "You don't see that here." };
+  }
+  const [item] = room.items.splice(index, 1);
+  state.player.inventory = state.player.inventory || [];
+  state.player.inventory.push(item);
+  return { state, message: `You pick up the ${item.name}.` };
+};

--- a/operational_modules/dungeon/index.js
+++ b/operational_modules/dungeon/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  actions: {
+    move: require('./actions/move'),
+    attack: require('./actions/attack'),
+    inspect: require('./actions/inspect'),
+    pickup: require('./actions/pickup'),
+  },
+  parseInput: require('./parser'),
+};

--- a/operational_modules/dungeon/parser.js
+++ b/operational_modules/dungeon/parser.js
@@ -1,0 +1,27 @@
+const synonyms = {
+  move: ['go', 'move', 'walk'],
+  attack: ['attack', 'hit', 'strike'],
+  inspect: ['look', 'inspect', 'examine'],
+  pickup: ['take', 'pickup', 'grab'],
+  quit: ['quit', 'exit']
+};
+
+function parseInput(input = '') {
+  const text = input.trim().toLowerCase();
+  if (!text) return { type: 'none' };
+  const [verb, ...rest] = text.split(/\s+/);
+  const arg = rest.join(' ');
+  for (const [type, words] of Object.entries(synonyms)) {
+    if (words.includes(verb)) {
+      const params = {};
+      if (type === 'move') params.direction = rest[0];
+      else if (type === 'attack') params.target = arg;
+      else if (type === 'inspect') params.target = arg || null;
+      else if (type === 'pickup') params.item = arg;
+      return { type, params };
+    }
+  }
+  return { type: 'unknown', raw: input };
+}
+
+module.exports = parseInput;

--- a/operational_modules/space/actions/attack.js
+++ b/operational_modules/space/actions/attack.js
@@ -1,0 +1,4 @@
+module.exports = function attack(state, params = {}) {
+  const target = params.target || 'empty space';
+  return { state, message: `You fire at ${target}, but nothing happens.` };
+};

--- a/operational_modules/space/actions/inspect.js
+++ b/operational_modules/space/actions/inspect.js
@@ -1,0 +1,12 @@
+module.exports = function inspect(state, params = {}) {
+  const target = params.target;
+  const ship = state.world.ships?.[state.player.ship];
+  if (!target) {
+    return { state, message: ship?.description || 'All systems nominal.' };
+  }
+  const item = ship?.items?.find(i => i.name === target);
+  if (item) {
+    return { state, message: item.description };
+  }
+  return { state, message: "Sensors detect nothing." };
+};

--- a/operational_modules/space/actions/move.js
+++ b/operational_modules/space/actions/move.js
@@ -1,0 +1,11 @@
+module.exports = function move(state, params = {}) {
+  const direction = params.direction;
+  const ship = state.world.ships?.[state.player.ship];
+  const next = ship?.routes?.[direction];
+  if (!next) {
+    return { state, message: "Course unavailable." };
+  }
+  state.player.ship = next;
+  const desc = state.world.ships?.[next]?.description || `You travel ${direction}.`;
+  return { state, message: desc };
+};

--- a/operational_modules/space/actions/pickup.js
+++ b/operational_modules/space/actions/pickup.js
@@ -1,0 +1,15 @@
+module.exports = function pickup(state, params = {}) {
+  const itemName = params.item;
+  const ship = state.world.ships?.[state.player.ship];
+  if (!itemName || !ship) {
+    return { state, message: 'Collect what?' };
+  }
+  const index = ship.items?.findIndex(i => i.name === itemName);
+  if (index === -1 || index === undefined) {
+    return { state, message: 'Item not found.' };
+  }
+  const [item] = ship.items.splice(index, 1);
+  state.player.cargo = state.player.cargo || [];
+  state.player.cargo.push(item);
+  return { state, message: `Collected ${item.name}.` };
+};

--- a/operational_modules/space/index.js
+++ b/operational_modules/space/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  actions: {
+    move: require('./actions/move'),
+    attack: require('./actions/attack'),
+    inspect: require('./actions/inspect'),
+    pickup: require('./actions/pickup'),
+  },
+  parseInput: require('./parser'),
+};

--- a/operational_modules/space/parser.js
+++ b/operational_modules/space/parser.js
@@ -1,0 +1,27 @@
+const synonyms = {
+  move: ['move', 'fly', 'thrust', 'go'],
+  attack: ['shoot', 'fire', 'attack'],
+  inspect: ['scan', 'inspect', 'look'],
+  pickup: ['collect', 'grab', 'take'],
+  quit: ['quit', 'exit']
+};
+
+function parseInput(input = '') {
+  const text = input.trim().toLowerCase();
+  if (!text) return { type: 'none' };
+  const [verb, ...rest] = text.split(/\s+/);
+  const arg = rest.join(' ');
+  for (const [type, words] of Object.entries(synonyms)) {
+    if (words.includes(verb)) {
+      const params = {};
+      if (type === 'move') params.direction = rest[0];
+      else if (type === 'attack') params.target = arg;
+      else if (type === 'inspect') params.target = arg || null;
+      else if (type === 'pickup') params.item = arg;
+      return { type, params };
+    }
+  }
+  return { type: 'unknown', raw: input };
+}
+
+module.exports = parseInput;


### PR DESCRIPTION
## Summary
- flesh out GameEngine with a CLI loop and action dispatch
- implement a basic command parser
- expand action handlers with move, inspect and pickup examples
- add simple console/DOM display layer
- wire the modules together and update documentation
- add dungeon and space operational modules

## Testing
- `node -e "const {engine}=require('./game_engine'); engine.handleInput('look');"`
- `node -e "const mod=require('./operational_modules/dungeon'); console.log(mod.parseInput('go north'));"`
- `node -e "const mod=require('./operational_modules/space'); console.log(mod.parseInput('fly alpha'));"`

------
https://chatgpt.com/codex/tasks/task_e_685060449fe08327a0289f4d7430288b