### PR TITLE
Add story loader and browser demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# sandbox
+# Sandbox
+
+This repository contains a small text adventure engine located in the `game_engine` directory. The engine supports a pluggable parser, action handlers and a basic display layer. Each file represents a major component of the architecture:
+
+- `GameEngine.js`: central game loop and state container
+- `InputParser.js`: command parser converting user text to actions
+- `ActionHandlers.js`: default action resolution functions
+- `Display.js`: output/rendering helper (console or DOM)
+- `StoryLoader.js`: helper to load story JSON files into engine state
+- `index.js`: convenience entry that wires the pieces together
+
+Additional operational modules are provided in the `operational_modules` folder. These demonstrate how different action sets and parsers can be swapped in:
+
+- `dungeon`: classic fantasy commands (go, attack, look, take)
+- `space`: space mission verbs (fly, shoot, scan, collect)
+
+Story modules located in the `story_modules` folder define the worlds used for testing. Each JSON file lists rooms (or ships), starting items and NPCs.
+
+- `dungeon.json`: small fantasy dungeon with rooms like the hall, armory and courtyard
+- `space.json`: starship adventure featuring locations such as the bridge and engine room
+
+A small `browser_bundle.js` and `index.html` demonstrate how the engine can run in a browser. The bundle exposes a global `TextAdventure` object used by the demo page.

--- a/browser_bundle.js
+++ b/browser_bundle.js
@@ -1,0 +1,106 @@
+(function(global){
+  // Display
+  function render(msg){
+    if (typeof document !== 'undefined'){
+      const box = document.getElementById('output');
+      if (box){
+        box.textContent += msg + '\n';
+        return;
+      }
+    }
+    console.log(msg);
+  }
+
+  // Parser
+  function parseInput(input=''){ 
+    const text = input.trim().toLowerCase();
+    if(!text) return {type:'none'};
+    const [verb,...rest] = text.split(/\s+/);
+    const arg = rest.join(' ');
+    switch(verb){
+      case 'go':
+      case 'move':
+        return {type:'move', params:{direction:rest[0]}};
+      case 'look':
+      case 'inspect':
+        return {type:'inspect', params:{target:arg||null}};
+      case 'take':
+      case 'pickup':
+        return {type:'pickup', params:{item:arg}};
+      case 'attack':
+        return {type:'attack', params:{target:arg}};
+      case 'quit':
+        return {type:'quit'};
+      default:
+        return {type:'unknown', raw:input};
+    }
+  }
+
+  // Actions
+  const actions = {
+    move(state, params={}){
+      const dir = params.direction;
+      const room = state.world.rooms?.[state.player.location];
+      const next = room?.exits?.[dir];
+      if(!next) return {state, message:"You can't go that way."};
+      state.player.location = next;
+      const desc = state.world.rooms[next]?.description || 'You arrive.';
+      return {state, message:desc};
+    },
+    inspect(state, params={}){
+      const target = params.target;
+      const room = state.world.rooms?.[state.player.location];
+      if(!target) return {state, message: room?.description || 'Nothing to see.'};
+      const item = room?.items?.find(i=>i.name===target);
+      if(item) return {state, message:item.description};
+      return {state, message:"You don't see that."};
+    },
+    pickup(state, params={}){
+      const itemName = params.item;
+      const room = state.world.rooms?.[state.player.location];
+      if(!itemName || !room) return {state, message:'Take what?'};
+      const idx = room.items?.findIndex(i=>i.name===itemName);
+      if(idx===-1 || idx===undefined) return {state,message:"You don't see that here."};
+      const [item] = room.items.splice(idx,1);
+      state.player.inventory = state.player.inventory || [];
+      state.player.inventory.push(item);
+      return {state, message:`You pick up the ${item.name}.`};
+    },
+    attack(state, params={}){
+      const target = params.target;
+      const room = state.world.rooms?.[state.player.location];
+      const npcName = target || room?.npcs?.[0];
+      if(!npcName) return {state,message:"There's nothing here to attack."};
+      const npc = state.world.npcs?.[npcName];
+      if(npc && npc.location===state.player.location){
+        delete state.world.npcs[npcName];
+        if(room && room.npcs) room.npcs = room.npcs.filter(n=>n!==npcName);
+        return {state,message:`You vanquish ${npcName}!`};
+      }
+      return {state,message:`You swing at ${npcName}, but miss.`};
+    },
+    quit(state){ return {state,message:'Goodbye!',quit:true}; }
+  };
+
+  // Engine
+  class GameEngine{
+    constructor(options={}){
+      this.state = options.state || {player:{location:'start'},world:{}};
+      this.parseInput = options.parser || parseInput;
+      this.actions = options.actions || actions;
+      this.render = options.render || render;
+      this.running = false;
+    }
+    handleInput(text){
+      const action = this.parseInput(text);
+      const handler = this.actions[action.type];
+      if(!handler){ this.render(`I don't understand "${text}".`); return; }
+      const result = handler(this.state, action.params||{});
+      if(result && result.state) this.state = result.state;
+      if(result && result.message) this.render(result.message);
+      if(result && result.quit) this.running=false;
+    }
+  }
+
+  global.TextAdventure = { GameEngine, parseInput, actions, render };
+})(typeof window !== 'undefined' ? window : global);

--- a/game_engine/ActionHandlers.js
+++ b/game_engine/ActionHandlers.js
@@ -1,0 +1,90 @@
+// Basic set of action handlers for the engine
+
+const actions = {
+  /**
+   * Move the player to an adjacent room if possible.
+   */
+  move(state, params = {}) {
+    const direction = params.direction;
+    const room = state.world.rooms?.[state.player.location];
+    const next = room?.exits?.[direction];
+
+    if (!next) {
+      return { state, message: "You can't go that way." };
+    }
+
+    state.player.location = next;
+    const desc = state.world.rooms[next]?.description || 'You arrive somewhere.';
+    return { state, message: desc };
+  },
+
+  /**
+   * Inspect the current room or an item (very simple implementation).
+   */
+  inspect(state, params = {}) {
+    const target = params.target;
+    const room = state.world.rooms?.[state.player.location];
+
+    if (!target) {
+      return { state, message: room?.description || 'Nothing of interest.' };
+    }
+
+    const item = room?.items?.find((i) => i.name === target);
+    if (item) {
+      return { state, message: item.description };
+    }
+
+    return { state, message: "You don't see that here." };
+  },
+
+  /**
+   * Pick up an item from the current room.
+   */
+  pickup(state, params = {}) {
+    const itemName = params.item;
+    const room = state.world.rooms?.[state.player.location];
+    if (!itemName || !room) {
+      return { state, message: "Take what?" };
+    }
+
+    const index = room.items?.findIndex((i) => i.name === itemName);
+    if (index === -1 || index === undefined) {
+      return { state, message: "You don't see that here." };
+    }
+
+    const [item] = room.items.splice(index, 1);
+    state.player.inventory = state.player.inventory || [];
+    state.player.inventory.push(item);
+    return { state, message: `You pick up the ${item.name}.` };
+  },
+
+  /**
+   * Simple attack handler targeting an NPC in the room.
+   */
+  attack(state, params = {}) {
+    const target = params.target;
+    const room = state.world.rooms?.[state.player.location];
+    const npcName = target || room?.npcs?.[0];
+    if (!npcName) {
+      return { state, message: "There's nothing here to attack." };
+    }
+    const npc = state.world.npcs?.[npcName];
+    if (npc && npc.location === state.player.location) {
+      delete state.world.npcs[npcName];
+      if (room && room.npcs) {
+        room.npcs = room.npcs.filter(n => n !== npcName);
+      }
+      return { state, message: `You vanquish ${npcName}!` };
+    }
+    return { state, message: `You swing at ${npcName}, but miss.` };
+  },
+
+  /**
+   * Quit the game loop.
+   */
+  quit(state) {
+    return { state, message: 'Goodbye!', quit: true };
+  },
+};
+
+module.exports = actions;

--- a/game_engine/Display.js
+++ b/game_engine/Display.js
@@ -1,0 +1,18 @@
+// Simple display layer used by the GameEngine
+
+/**
+ * Render output to the browser or console. If an element with id `output`
+ * exists, append the text to it. Otherwise fall back to console.log.
+ */
+function render(output) {
+  if (typeof document !== 'undefined') {
+    const box = document.getElementById('output');
+    if (box) {
+      box.textContent += output + '\n';
+      return;
+    }
+  }
+  console.log(output);
+}
+
+module.exports = { render };

--- a/game_engine/GameEngine.js
+++ b/game_engine/GameEngine.js
@@ -1,0 +1,103 @@
+// Basic text adventure game engine with helper utilities
+const readline = require('readline');
+const fs = require('fs');
+const loadStoryModule = require('./StoryLoader');
+
+class GameEngine {
+  constructor(options = {}) {
+    // Holds the full game state (player info, world data, etc.)
+    this.state = options.state || {
+      player: { location: 'start' },
+      world: {},
+    };
+
+    // Parser converts raw text to action objects
+    this.parseInput = options.parser || ((text) => ({ type: 'unknown', raw: text }));
+
+    // Action handlers (move, inspect, etc.)
+    this.actions = options.actions || {};
+
+    // Display/render callback
+    this.render = options.render || ((msg) => console.log(msg));
+
+    this.running = false;
+  }
+
+  loadStory(filePath) {
+    const storyState = loadStoryModule(filePath);
+    this.state = {
+      ...this.state,
+      ...storyState,
+      player: { ...this.state.player, ...storyState.player },
+      world: { ...this.state.world, ...storyState.world },
+    };
+  }
+
+  saveState(filePath) {
+    fs.writeFileSync(filePath, JSON.stringify(this.state, null, 2));
+  }
+
+  loadState(filePath) {
+    const data = fs.readFileSync(filePath, 'utf8');
+    this.state = JSON.parse(data);
+  }
+
+  registerAction(name, handler) {
+    this.actions[name] = handler;
+  }
+
+  /**
+   * Process a single turn of input.
+   * Parses the text, dispatches to the correct action handler, updates state,
+   * and renders the resulting output.
+   */
+  handleInput(text) {
+    const action = this.parseInput(text);
+    const handler = this.actions[action.type];
+
+    if (!handler) {
+      this.render(`I don't understand "${text}".`);
+      return;
+    }
+
+    const result = handler(this.state, action.params || {});
+
+    if (result && result.state) {
+      this.state = result.state;
+    }
+
+    if (result && result.message) {
+      this.render(result.message);
+    }
+
+    if (result && result.quit) {
+      this.stop();
+    }
+  }
+
+  /**
+   * Start a basic CLI loop for testing. Each line of input is processed as a
+   * turn. Call stop() to end the loop.
+   */
+  startCLI() {
+    this.running = true;
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const prompt = () => {
+      if (!this.running) {
+        rl.close();
+        return;
+      }
+      rl.question('> ', (answer) => {
+        this.handleInput(answer);
+        prompt();
+      });
+    };
+    prompt();
+  }
+
+  stop() {
+    this.running = false;
+  }
+}
+
+module.exports = GameEngine;

--- a/game_engine/InputParser.js
+++ b/game_engine/InputParser.js
@@ -1,0 +1,36 @@
+// Basic command parser for the text adventure engine
+
+/**
+ * Convert raw user text into an action object that the engine understands.
+ * @param {string} input
+ * @returns {{type: string, params: object}}
+ */
+function parseInput(input) {
+  const text = (input || '').trim().toLowerCase();
+
+  if (text === '') return { type: 'none' };
+
+  const [verb, ...rest] = text.split(/\s+/);
+  const arg = rest.join(' ');
+
+  switch (verb) {
+    case 'go':
+    case 'move':
+      return { type: 'move', params: { direction: rest[0] } };
+    case 'look':
+    case 'inspect':
+      return { type: 'inspect', params: { target: arg || null } };
+    case 'take':
+    case 'pickup':
+      return { type: 'pickup', params: { item: arg } };
+    case 'attack':
+    case 'hit':
+      return { type: 'attack', params: { target: arg } };
+    case 'quit':
+      return { type: 'quit' };
+    default:
+      return { type: 'unknown', raw: input };
+  }
+}
+
+module.exports = parseInput;

--- a/game_engine/StoryLoader.js
+++ b/game_engine/StoryLoader.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+
+function loadStoryModule(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const data = JSON.parse(raw);
+  const state = { world: {}, player: {} };
+
+  if (data.rooms) {
+    state.world.rooms = data.rooms;
+    state.player.location = Object.keys(data.rooms)[0];
+  }
+  if (data.ships) {
+    state.world.ships = data.ships;
+    state.player.ship = Object.keys(data.ships)[0];
+  }
+  if (data.npcs) {
+    state.world.npcs = data.npcs;
+  }
+  if (data.items) {
+    state.world.items = data.items;
+  }
+
+  return state;
+}
+
+module.exports = loadStoryModule;

--- a/game_engine/index.js
+++ b/game_engine/index.js
@@ -1,0 +1,27 @@
+const GameEngine = require('./GameEngine');
+const parseInput = require('./InputParser');
+const actionHandlers = require('./ActionHandlers');
+const { render } = require('./Display');
+const loadStoryModule = require('./StoryLoader');
+
+// Create an engine instance wired with the default parser and display.
+const engine = new GameEngine({
+  parser: parseInput,
+  actions: actionHandlers,
+  render,
+});
+
+module.exports = {
+  GameEngine,
+  parseInput,
+  actions: actionHandlers,
+  render,
+  engine,
+  loadStoryModule,
+};
+
+// If executed directly via `node game_engine`, start the CLI loop.
+if (require.main === module) {
+  engine.render('Welcome to the text adventure!');
+  engine.startCLI();
+}

--- a/index.html
+++ b/index.html
@@ -1,3 +1,26 @@
-cd architectVS7.github.io
-
-echo "Hello World" > index.html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Text Adventure Demo</title>
+  <style>
+    #output { white-space: pre-wrap; border: 1px solid #ccc; padding: 10px; height: 200px; overflow-y: auto; }
+  </style>
+</head>
+<body>
+  <div id="output"></div>
+  <input id="command" type="text" placeholder="Enter command" />
+  <button id="send">Send</button>
+  <script src="browser_bundle.js"></script>
+  <script>
+    const { GameEngine, parseInput, actions, render } = window.TextAdventure;
+    const engine = new GameEngine({ parser: parseInput, actions, render });
+    engine.render('Welcome to the text adventure!');
+    document.getElementById('send').addEventListener('click', () => {
+      const cmd = document.getElementById('command').value;
+      engine.handleInput(cmd);
+      document.getElementById('command').value = '';
+    });
+  </script>
+</body>
+</html>

--- a/operational_modules/dungeon/actions/attack.js
+++ b/operational_modules/dungeon/actions/attack.js
@@ -1,0 +1,4 @@
+module.exports = function attack(state, params = {}) {
+  const target = params.target || 'the darkness';
+  return { state, message: `You attack ${target}, but nothing happens.` };
+};

--- a/operational_modules/dungeon/actions/inspect.js
+++ b/operational_modules/dungeon/actions/inspect.js
@@ -1,0 +1,12 @@
+module.exports = function inspect(state, params = {}) {
+  const target = params.target;
+  const room = state.world.rooms?.[state.player.location];
+  if (!target) {
+    return { state, message: room?.description || 'There is nothing to see.' };
+  }
+  const item = room?.items?.find(i => i.name === target);
+  if (item) {
+    return { state, message: item.description };
+  }
+  return { state, message: "You don't see that here." };
+};

--- a/operational_modules/dungeon/actions/move.js
+++ b/operational_modules/dungeon/actions/move.js
@@ -1,0 +1,11 @@
+module.exports = function move(state, params = {}) {
+  const direction = params.direction;
+  const room = state.world.rooms?.[state.player.location];
+  const next = room?.exits?.[direction];
+  if (!next) {
+    return { state, message: "You can't go that way." };
+  }
+  state.player.location = next;
+  const desc = state.world.rooms?.[next]?.description || `You move ${direction}.`;
+  return { state, message: desc };
+};

--- a/operational_modules/dungeon/actions/pickup.js
+++ b/operational_modules/dungeon/actions/pickup.js
@@ -1,0 +1,15 @@
+module.exports = function pickup(state, params = {}) {
+  const itemName = params.item;
+  const room = state.world.rooms?.[state.player.location];
+  if (!itemName || !room) {
+    return { state, message: 'Take what?' };
+  }
+  const index = room.items?.findIndex(i => i.name === itemName);
+  if (index === -1 || index === undefined) {
+    return { state, message: "You don't see that here." };
+  }
+  const [item] = room.items.splice(index, 1);
+  state.player.inventory = state.player.inventory || [];
+  state.player.inventory.push(item);
+  return { state, message: `You pick up the ${item.name}.` };
+};

--- a/operational_modules/dungeon/index.js
+++ b/operational_modules/dungeon/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  actions: {
+    move: require('./actions/move'),
+    attack: require('./actions/attack'),
+    inspect: require('./actions/inspect'),
+    pickup: require('./actions/pickup'),
+  },
+  parseInput: require('./parser'),
+};

--- a/operational_modules/dungeon/parser.js
+++ b/operational_modules/dungeon/parser.js
@@ -1,0 +1,27 @@
+const synonyms = {
+  move: ['go', 'move', 'walk'],
+  attack: ['attack', 'hit', 'strike'],
+  inspect: ['look', 'inspect', 'examine'],
+  pickup: ['take', 'pickup', 'grab'],
+  quit: ['quit', 'exit']
+};
+
+function parseInput(input = '') {
+  const text = input.trim().toLowerCase();
+  if (!text) return { type: 'none' };
+  const [verb, ...rest] = text.split(/\s+/);
+  const arg = rest.join(' ');
+  for (const [type, words] of Object.entries(synonyms)) {
+    if (words.includes(verb)) {
+      const params = {};
+      if (type === 'move') params.direction = rest[0];
+      else if (type === 'attack') params.target = arg;
+      else if (type === 'inspect') params.target = arg || null;
+      else if (type === 'pickup') params.item = arg;
+      return { type, params };
+    }
+  }
+  return { type: 'unknown', raw: input };
+}
+
+module.exports = parseInput;

--- a/operational_modules/space/actions/attack.js
+++ b/operational_modules/space/actions/attack.js
@@ -1,0 +1,4 @@
+module.exports = function attack(state, params = {}) {
+  const target = params.target || 'empty space';
+  return { state, message: `You fire at ${target}, but nothing happens.` };
+};

--- a/operational_modules/space/actions/inspect.js
+++ b/operational_modules/space/actions/inspect.js
@@ -1,0 +1,12 @@
+module.exports = function inspect(state, params = {}) {
+  const target = params.target;
+  const ship = state.world.ships?.[state.player.ship];
+  if (!target) {
+    return { state, message: ship?.description || 'All systems nominal.' };
+  }
+  const item = ship?.items?.find(i => i.name === target);
+  if (item) {
+    return { state, message: item.description };
+  }
+  return { state, message: "Sensors detect nothing." };
+};

--- a/operational_modules/space/actions/move.js
+++ b/operational_modules/space/actions/move.js
@@ -1,0 +1,11 @@
+module.exports = function move(state, params = {}) {
+  const direction = params.direction;
+  const ship = state.world.ships?.[state.player.ship];
+  const next = ship?.routes?.[direction];
+  if (!next) {
+    return { state, message: "Course unavailable." };
+  }
+  state.player.ship = next;
+  const desc = state.world.ships?.[next]?.description || `You travel ${direction}.`;
+  return { state, message: desc };
+};

--- a/operational_modules/space/actions/pickup.js
+++ b/operational_modules/space/actions/pickup.js
@@ -1,0 +1,15 @@
+module.exports = function pickup(state, params = {}) {
+  const itemName = params.item;
+  const ship = state.world.ships?.[state.player.ship];
+  if (!itemName || !ship) {
+    return { state, message: 'Collect what?' };
+  }
+  const index = ship.items?.findIndex(i => i.name === itemName);
+  if (index === -1 || index === undefined) {
+    return { state, message: 'Item not found.' };
+  }
+  const [item] = ship.items.splice(index, 1);
+  state.player.cargo = state.player.cargo || [];
+  state.player.cargo.push(item);
+  return { state, message: `Collected ${item.name}.` };
+};

--- a/operational_modules/space/index.js
+++ b/operational_modules/space/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  actions: {
+    move: require('./actions/move'),
+    attack: require('./actions/attack'),
+    inspect: require('./actions/inspect'),
+    pickup: require('./actions/pickup'),
+  },
+  parseInput: require('./parser'),
+};

--- a/operational_modules/space/parser.js
+++ b/operational_modules/space/parser.js
@@ -1,0 +1,27 @@
+const synonyms = {
+  move: ['move', 'fly', 'thrust', 'go'],
+  attack: ['shoot', 'fire', 'attack'],
+  inspect: ['scan', 'inspect', 'look'],
+  pickup: ['collect', 'grab', 'take'],
+  quit: ['quit', 'exit']
+};
+
+function parseInput(input = '') {
+  const text = input.trim().toLowerCase();
+  if (!text) return { type: 'none' };
+  const [verb, ...rest] = text.split(/\s+/);
+  const arg = rest.join(' ');
+  for (const [type, words] of Object.entries(synonyms)) {
+    if (words.includes(verb)) {
+      const params = {};
+      if (type === 'move') params.direction = rest[0];
+      else if (type === 'attack') params.target = arg;
+      else if (type === 'inspect') params.target = arg || null;
+      else if (type === 'pickup') params.item = arg;
+      return { type, params };
+    }
+  }
+  return { type: 'unknown', raw: input };
+}
+
+module.exports = parseInput;

--- a/story_modules/dungeon.json
+++ b/story_modules/dungeon.json
@@ -1,0 +1,72 @@
+{
+  "rooms": {
+    "entrance": {
+      "description": "The dungeon entrance is dim and foreboding.",
+      "exits": { "north": "hall" },
+      "items": [
+        { "name": "map", "description": "A tattered map showing nearby rooms." }
+      ]
+    },
+    "hall": {
+      "description": "A long hallway lined with torches.",
+      "exits": { "south": "entrance", "east": "armory", "west": "library", "north": "courtyard" },
+      "items": [
+        { "name": "coin", "description": "A shiny gold coin lost by someone." }
+      ],
+      "npcs": ["guard"]
+    },
+    "armory": {
+      "description": "Racks of weapons and armor fill the room.",
+      "exits": { "west": "hall" },
+      "items": [
+        { "name": "sword", "description": "A sharp steel sword." },
+        { "name": "shield", "description": "A sturdy wooden shield." }
+      ]
+    },
+    "library": {
+      "description": "Dusty shelves of ancient books.",
+      "exits": { "east": "hall" },
+      "items": [
+        { "name": "scroll", "description": "An old scroll with faded writing." }
+      ]
+    },
+    "courtyard": {
+      "description": "An open courtyard with a view of the sky.",
+      "exits": { "south": "hall", "down": "cell" },
+      "npcs": ["merchant"]
+    },
+    "cell": {
+      "description": "A dark prison cell below the courtyard.",
+      "exits": { "up": "courtyard" },
+      "items": [
+        { "name": "key", "description": "A rusty iron key." }
+      ],
+      "npcs": ["prisoner"]
+    }
+  },
+  "npcs": {
+    "guard": {
+      "location": "hall",
+      "dialogue": "The guard eyes you suspiciously.",
+      "stats": { "hp": 10 }
+    },
+    "merchant": {
+      "location": "courtyard",
+      "dialogue": "Care to trade?",
+      "stats": { "hp": 8 }
+    },
+    "prisoner": {
+      "location": "cell",
+      "dialogue": "Please get me out of here!",
+      "stats": { "hp": 5 }
+    }
+  },
+  "items": {
+    "map": { "location": "entrance", "description": "A tattered map showing nearby rooms." },
+    "coin": { "location": "hall", "description": "A shiny gold coin lost by someone." },
+    "sword": { "location": "armory", "description": "A sharp steel sword." },
+    "shield": { "location": "armory", "description": "A sturdy wooden shield." },
+    "scroll": { "location": "library", "description": "An old scroll with faded writing." },
+    "key": { "location": "cell", "description": "A rusty iron key." }
+  }
+}

--- a/story_modules/space.json
+++ b/story_modules/space.json
@@ -1,0 +1,74 @@
+{
+  "ships": {
+    "dock": {
+      "description": "You stand at the main docking bay of the starship.",
+      "routes": { "north": "bridge", "west": "cargo_hold" },
+      "items": [
+        { "name": "manifest", "description": "Cargo manifest for the ship." }
+      ]
+    },
+    "bridge": {
+      "description": "The command bridge is filled with blinking consoles.",
+      "routes": { "south": "dock", "east": "engine_room", "north": "lab" },
+      "items": [
+        { "name": "console", "description": "A control console." }
+      ],
+      "npcs": ["captain"]
+    },
+    "engine_room": {
+      "description": "Engines hum with power.",
+      "routes": { "west": "bridge" },
+      "items": [
+        { "name": "toolkit", "description": "A set of engineering tools." }
+      ],
+      "npcs": ["engineer"]
+    },
+    "lab": {
+      "description": "Research equipment lines the walls.",
+      "routes": { "south": "bridge", "north": "asteroid_field" },
+      "items": [
+        { "name": "sample", "description": "A mysterious biological sample." }
+      ],
+      "npcs": ["scientist"]
+    },
+    "asteroid_field": {
+      "description": "Floating rocks surround the ship in this asteroid field.",
+      "routes": { "south": "lab" },
+      "items": [
+        { "name": "minerals", "description": "Rare minerals collected from asteroids." }
+      ]
+    },
+    "cargo_hold": {
+      "description": "Crates of supplies are stacked high.",
+      "routes": { "east": "dock" },
+      "items": [
+        { "name": "crate", "description": "A heavy crate filled with supplies." }
+      ]
+    }
+  },
+  "npcs": {
+    "captain": {
+      "location": "bridge",
+      "dialogue": "Maintain course.",
+      "stats": { "hp": 12 }
+    },
+    "engineer": {
+      "location": "engine_room",
+      "dialogue": "Engines at optimal levels.",
+      "stats": { "hp": 10 }
+    },
+    "scientist": {
+      "location": "lab",
+      "dialogue": "These samples are fascinating.",
+      "stats": { "hp": 9 }
+    }
+  },
+  "items": {
+    "manifest": { "location": "dock", "description": "Cargo manifest for the ship." },
+    "console": { "location": "bridge", "description": "A control console." },
+    "toolkit": { "location": "engine_room", "description": "A set of engineering tools." },
+    "sample": { "location": "lab", "description": "A mysterious biological sample." },
+    "minerals": { "location": "asteroid_field", "description": "Rare minerals collected from asteroids." },
+    "crate": { "location": "cargo_hold", "description": "A heavy crate filled with supplies." }
+  }
+}


### PR DESCRIPTION
## Summary
- implement story module loader utility
- expand default action handlers with attack and quit
- provide state save/load methods on `GameEngine`
- create a browser bundle and sample page
- update README to document new components

## Testing
- `node -e "const {engine}=require('./game_engine'); engine.handleInput('look');"`
- `node -e "const mod=require('./operational_modules/dungeon'); console.log(mod.parseInput('go north'));"`
- `node -e "const fs=require('fs'); console.log(Object.keys(JSON.parse(fs.readFileSync('./story_modules/dungeon.json','utf8')).rooms));"`
- `node - <<'NODE'
const {GameEngine, parseInput, actions, render, loadStoryModule} = require('./game_engine');
const state = loadStoryModule('./story_modules/dungeon.json');
const engine = new GameEngine({parser: parseInput, actions, render, state});
engine.handleInput('go north');
engine.handleInput('attack guard');
engine.handleInput('quit');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_685060449fe08327a0289f4d7430288b